### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,6 @@ For Debian `rsvg-convert` in located in the `librsvg2-bin` package.
 sudo apt-get install librsvg2-bin
 ```
 
-##Authors
+## Authors
 - Damian Kaczmarek <rush@rushbase.net> [@Rush](https://github.com/Rush)
 - Dominykas Blyžė <hello@dominykas.com> [@dominykas](https://github.com/dominykas)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
