### PR TITLE
fix: update svgo to 1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lodash.indexby": "^3.0.0",
     "mkdirp": "^0.5.0",
     "optimist": "~0.6.0",
-    "svgo": "0.4.4",
+    "svgo": "1.1.1",
     "xml2js": "^0.4.5"
   }
 }


### PR DESCRIPTION
npm is reporting a security vulnerability in svgo@0.4.4. As far as I can tell, there are no true breaking changes; just that svgo@1.0.0 started requiring Node v4+: https://github.com/svg/svgo/blob/master/CHANGELOG.md#---100--30102017

npm audit:

<details>
<summary>click to see output</summary>

```

                       === npm audit security report ===

┌──────────────────────────────────────────────────────────────────────────────┐
│                                Manual Review                                 │
│            Some vulnerabilities require your attention to resolve            │
│                                                                              │
│         Visit https://go.npm.me/audit-guide for additional guidance          │
└──────────────────────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Moderate      │ Regular Expression Denial of Service                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ underscore.string                                            │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=3.3.5                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ font-awesome-svg-png                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ font-awesome-svg-png > svgo > js-yaml > argparse >           │
│               │ underscore.string                                            │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/745                       │
└───────────────┴──────────────────────────────────────────────────────────────┘
found 1 moderate severity vulnerability in 9871 scanned packages
  1 vulnerability requires manual review. See the full report for details.

```

</details>